### PR TITLE
gopher_msgs: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -129,11 +129,20 @@ repositories:
       type: git
       url: https://bitbucket.org/yujinrobot/gopher_msgs.git
       version: indigo
+    release:
+      packages:
+      - gopher_msgs
+      - gopher_navi_msgs
+      - gopher_semantic_msgs
+      - gopher_std_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://bitbucket.org/yujinrobot/gopher_msgs-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://bitbucket.org/yujinrobot/gopher_msgs.git
       version: indigo
     status: developed
-
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `gopher_msgs` to `0.2.0-0`:
- upstream repository: https://bitbucket.org/yujinrobot/gopher_msgs.git
- release repository: https://bitbucket.org/yujinrobot/gopher_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## gopher_msgs

```
* many message types to support the field testing in spain
```
## gopher_navi_msgs

```
* supporting multi-map teleports
```
## gopher_semantic_msgs

```
* semantic locations, elevators, docking stations
```
## gopher_std_msgs

```
* deliveries, locations, sensors
```
