### PR TITLE
rocon_msgs: 0.8.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -144,5 +144,33 @@ repositories:
       url: git@bitbucket.org:yujinrobot/gopher_msgs.git
       version: indigo
     status: developed
+  rocon_msgs:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_msgs.git
+      version: gopher
+    release:
+      packages:
+      - concert_msgs
+      - concert_service_msgs
+      - concert_workflow_engine_msgs
+      - gateway_msgs
+      - rocon_app_manager_msgs
+      - rocon_device_msgs
+      - rocon_interaction_msgs
+      - rocon_msgs
+      - rocon_service_pair_msgs
+      - rocon_std_msgs
+      - rocon_tutorial_msgs
+      - scheduler_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon_msgs-release.git
+      version: 0.8.1-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_msgs.git
+      version: gopher
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_msgs` to `0.8.1-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_msgs.git
- release repository: git@bitbucket.org:yujinrobot/rocon_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon_interaction_msgs

```
* support the new pairing rapp goals
```
## rocon_std_msgs

```
* a useful empty string service
```
