### PR TITLE
somanet_msgs: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -172,5 +172,20 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: gopher
     status: developed
+  somanet_msgs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/somanet_msgs.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/somanet_msgs-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/somanet_msgs.git
+      version: indigo
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `somanet_msgs` to `0.1.1-0`:
- upstream repository: https://github.com/yujinrobot/somanet_msgs.git
- release repository: git@bitbucket.org:yujinrobot/somanet_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
