### PR TITLE
dslam_msgs: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
+  dslam_msgs:
+    doc:
+      type: git
+      url: git@bitbucket.org:yujinrobot/dslam_msgs.git
+      version: gopher
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/dslam_msgs-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: git@bitbucket.org:yujinrobot/dslam_msgs.git
+      version: gopher
+    status: developed
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dslam_msgs` to `0.4.0-0`:
- upstream repository: git@bitbucket.org:yujinrobot/dslam_msgs.git
- release repository: git@bitbucket.org:yujinrobot/dslam_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
