### PR TITLE
rocon_tools: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -172,5 +172,35 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: gopher
     status: developed
+  rocon_tools:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_tools.git
+      version: gopher
+    release:
+      packages:
+      - rocon_bubble_icons
+      - rocon_console
+      - rocon_ebnf
+      - rocon_icons
+      - rocon_interactions
+      - rocon_launch
+      - rocon_master_info
+      - rocon_python_comms
+      - rocon_python_redis
+      - rocon_python_utils
+      - rocon_python_wifi
+      - rocon_semantic_version
+      - rocon_tools
+      - rocon_uri
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon_tools-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_tools.git
+      version: gopher
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tools` to `0.3.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tools.git
- release repository: git@bitbucket.org:yujinrobot/rocon_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon_interactions

```
* overhauled for better pairing management
* user side can now be dependent on a paired rapp
```
## rocon_python_comms

```
* lots of minor api added
```
## rocon_python_utils

```
* a few new api
```
