### PR TITLE
rocon_qt_gui: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -172,5 +172,36 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: gopher
     status: developed
+  rocon_qt_gui:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_qt_gui.git
+      version: gopher
+    release:
+      packages:
+      - concert_admin_app
+      - concert_conductor_graph
+      - concert_qt_image_stream
+      - concert_qt_make_a_map
+      - concert_qt_map_annotation
+      - concert_qt_service_info
+      - concert_qt_teleop
+      - rocon_gateway_graph
+      - rocon_qt_app_manager
+      - rocon_qt_gui
+      - rocon_qt_library
+      - rocon_qt_listener
+      - rocon_qt_master_info
+      - rocon_qt_teleop
+      - rocon_remocon
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon_qt_gui-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_qt_gui.git
+      version: gopher
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_qt_gui` to `0.8.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_qt_gui.git
- release repository: git@bitbucket.org:yujinrobot/rocon_qt_gui-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon_qt_app_manager

```
* bugfix running rapp display in the main panel
* bugfix start/stop bingle with child/parent rapps
* checkboxes for boolean args
```
## rocon_qt_master_info

```
* now displays the rocon uri of the master as well
```
## rocon_remocon

```
* major revamp to be similar to the nice qt app manager design
* support for starting/stopping one sided interactions
* support for interactions that depend on running rapps
* regression: no longer supports multimaster connections, needs to be FIXED
```
