### PR TITLE
rocon_multimaster: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -172,5 +172,29 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: gopher
     status: developed
+  rocon_multimaster:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_multimaster.git
+      version: gopher
+    release:
+      packages:
+      - rocon_gateway
+      - rocon_gateway_tests
+      - rocon_gateway_utils
+      - rocon_hub
+      - rocon_hub_client
+      - rocon_multimaster
+      - rocon_test
+      - rocon_unreliable_experiments
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon_multimaster-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_multimaster.git
+      version: gopher
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_multimaster` to `0.8.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_multimaster.git
- release repository: git@bitbucket.org:yujinrobot/rocon_multimaster-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon_gateway

```
* many gateway connection bugfixes
* gateway tests again functional
```
