### PR TITLE
rocon_app_platform: 0.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -144,6 +144,26 @@ repositories:
       url: git@bitbucket.org:yujinrobot/gopher_msgs.git
       version: indigo
     status: developed
+  rocon_app_platform:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_app_platform.git
+      version: gopher
+    release:
+      packages:
+      - rocon_app_manager
+      - rocon_app_platform
+      - rocon_app_utilities
+      - rocon_apps
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon_app_platform-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_app_platform.git
+      version: gopher
+    status: developed
   rocon_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.8.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_app_platform.git
- release repository: git@bitbucket.org:yujinrobot/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon_app_manager

```
* provide args to the user so they can prepare for unique namespacing if necessary
* move rapp launching into the root namespace and let the user decide where handles should go
* advertise the rapp manager handles on the gateway by default for concert clients
* simplified launchers into standalone and concert client
* split standalone and concert classes rather than trying to mash them as one
```
## rocon_app_platform

```
* rapps now launching in the root namespace, let the user decide
```
