### PR TITLE
elevator_interactions: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -139,6 +139,28 @@ repositories:
       url: https://github.com/stonier/ecl_tools.git
       version: indigo
     status: developed
+  elevator_interactions:
+    doc:
+      type: git
+      url: git@bitbucket.org:yujinrobot/elevator_interactions.git
+      version: indigo
+    release:
+      packages:
+      - elevator_controller_interface
+      - elevator_interactions
+      - elevator_interactions_msgs
+      - elevator_operator
+      - elevator_operator_2jsoft
+      - elevator_operator_modbus
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/elevator_interactions-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: git@bitbucket.org:yujinrobot/elevator_interactions.git
+      version: indigo
+    status: developed
   gopher_msgs:
     doc:
       type: git
@@ -206,21 +228,6 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_msgs.git
       version: gopher
-    status: developed
-  somanet_msgs:
-    doc:
-      type: git
-      url: https://github.com/yujinrobot/somanet_msgs.git
-      version: indigo
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: git@bitbucket.org:yujinrobot/somanet_msgs-release.git
-      version: 0.1.1-0
-    source:
-      type: git
-      url: https://github.com/yujinrobot/somanet_msgs.git
-      version: indigo
     status: developed
   rocon_multimaster:
     doc:
@@ -306,6 +313,21 @@ repositories:
       type: git
       url: https://github.com/robotics-in-concert/rocon_tools.git
       version: gopher
+    status: developed
+  somanet_msgs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/somanet_msgs.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/somanet_msgs-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/yujinrobot/somanet_msgs.git
+      version: indigo
     status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `elevator_interactions` to `0.1.0-0`:
- upstream repository: git@bitbucket.org:yujinrobot/elevator_interactions.git
- release repository: git@bitbucket.org:yujinrobot/elevator_interactions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
