### PR TITLE
gopher_crazy_hospital: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -161,6 +161,28 @@ repositories:
       url: git@bitbucket.org:yujinrobot/elevator_interactions.git
       version: indigo
     status: developed
+  gopher_crazy_hospital:
+    doc:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_crazy_hospital.git
+      version: indigo
+    release:
+      packages:
+      - gopher_behaviours
+      - gopher_configuration
+      - gopher_crazy_hospital
+      - gopher_semantics
+      - marco_polo
+      - py_trees
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/gopher_crazy_hospital-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_crazy_hospital.git
+      version: indigo
+    status: developed
   gopher_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gopher_crazy_hospital` to `0.1.1-0`:
- upstream repository: git@bitbucket.org:yujinrobot/gopher_crazy_hospital.git
- release repository: git@bitbucket.org:yujinrobot/gopher_crazy_hospital-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## gopher_behaviours

```
* topological planning of a delivery subtree across maps
* elevator behaviours
* integration of starting/finishing behaviours with deliveries
* docking/undocking behaviours
* parking/unparking behaviours
* behaviour tree for deliveries
* simple behaviours for move/wait deliveries
```
## gopher_configuration

```
* aliases for sounds
* aliases for batteries
* aliases for led patterns
* names for basic topics/services in gopher
```
## gopher_crazy_hospital

```
* gopher_configuration added, a means to more easily configure a gopher robot
* gopher_behaviours added, specialised behaviours for basic delivery types
* gopher_semantics added, first iteration of semantics...using yamls
* marco_polo added, handles map switching and teleporting across maps
* py_trees added, a behaviour tree approach to controlling a whole robot
```
## gopher_semantics

```
* semantics for docking stations
* semantics for elevators
* semantics for locations
* first iteration of semantics from yaml
```
## marco_polo

```
* script for teleporting on the command line
* script for downloading maps
* node for implementing teleports/map switching
```
## py_trees

```
* lots of bugfixing stabilising py_trees for the spain field test
* complement decorator for behaviours
* dot tree views
* ascii tree and tick views
* use generators and visitors to more efficiently walk/introspect trees
* a first implementation of behaviour trees in python
```
