### PR TITLE
gopher_rocon: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -203,6 +203,26 @@ repositories:
       url: git@bitbucket.org:yujinrobot/gopher_msgs.git
       version: indigo
     status: developed
+  gopher_rocon:
+    doc:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_rocon.git
+      version: indigo
+    release:
+      packages:
+      - gopher_rocon
+      - gopher_rocon_bootstrap
+      - gopher_tasks
+      - gopher_webui
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/gopher_rocon-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_rocon.git
+      version: indigo
+    status: developed
   rocon_app_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gopher_rocon` to `0.2.1-0`:
- upstream repository: git@bitbucket.org:yujinrobot/gopher_rocon.git
- release repository: git@bitbucket.org:yujinrobot/gopher_rocon-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
