### PR TITLE
gopher_rapps: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -203,6 +203,21 @@ repositories:
       url: git@bitbucket.org:yujinrobot/gopher_msgs.git
       version: indigo
     status: developed
+  gopher_rapps:
+    doc:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_rapps.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/gopher_rapps-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_rapps.git
+      version: indigo
+    status: developed
   gopher_rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gopher_rapps` to `0.1.1-0`:
- upstream repository: git@bitbucket.org:yujinrobot/gopher_rapps.git
- release repository: git@bitbucket.org:yujinrobot/gopher_rapps-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## gopher_rapps

```
* first iteration of parent delivery rapp
```
