### PR TITLE
flask-ext-catkin: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -172,7 +172,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:yujinrobot/flask-ext-catkin-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/asmodehn/flask-ext-catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flask-ext-catkin` to `0.1.1-0`:
- upstream repository: https://github.com/asmodehn/flask-ext-catkin.git
- release repository: git@bitbucket.org:yujinrobot/flask-ext-catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-0`
