### PR TITLE
celeros: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6,6 +6,21 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
+  celeros:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/celeros.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/celeros-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/celeros.git
+      version: indigo-devel
+    status: developed
   dslam_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `celeros` to `0.0.2-0`:
- upstream repository: https://github.com/asmodehn/celeros.git
- release repository: git@bitbucket.org:yujinrobot/celeros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
