### PR TITLE
rocon_tutorials: 0.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -404,6 +404,24 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_tools.git
       version: gopher
     status: developed
+  rocon_tutorials:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_tutorials.git
+      version: gopher
+    release:
+      packages:
+      - rocon_gateway_tutorials
+      - rocon_tutorials
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon_tutorials-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_tutorials.git
+      version: gopher
+    status: developed
   rostful:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_tutorials` to `0.7.0-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_tutorials.git
- release repository: git@bitbucket.org:yujinrobot/rocon_tutorials-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon_gateway_tutorials

```
passing the gateway interface to buccaneer launch file.
```
## rocon_tutorials
- No changes
