### PR TITLE
rocon_concert: 0.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -291,6 +291,27 @@ repositories:
       url: https://github.com/robotics-in-concert/rocon_app_platform.git
       version: gopher
     status: developed
+  rocon_concert:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_concert.git
+      version: gopher
+    release:
+      packages:
+      - concert_conductor
+      - concert_master
+      - concert_software_farmer
+      - concert_utilities
+      - rocon_concert
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon_concert-release.git
+      version: 0.7.1-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon_concert.git
+      version: gopher
+    status: developed
   rocon_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_concert` to `0.7.1-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon_concert.git
- release repository: git@bitbucket.org:yujinrobot/rocon_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## concert_conductor

```
* disable debug mode
* all bugs for new shiny conductor ironed out
* working with reduced states
* dismembered the invite process
* use new parameters structure
```
## concert_master

```
* directly call the conductor script
* delete cruft and scaled down launcher
```
## concert_software_farmer
- No changes
## concert_utilities
- No changes
