### PR TITLE
rocon: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -271,6 +271,21 @@ repositories:
       url: git@bitbucket.org:yujinrobot/gopher_rocon.git
       version: indigo
     status: developed
+  rocon:
+    doc:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon.git
+      version: gopher
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/rocon-release.git
+      version: 0.7.2-0
+    source:
+      type: git
+      url: https://github.com/robotics-in-concert/rocon.git
+      version: gopher
+    status: developed
   rocon_app_platform:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon` to `0.7.2-0`:
- upstream repository: https://github.com/robotics-in-concert/rocon.git
- release repository: git@bitbucket.org:yujinrobot/rocon-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## rocon

```
* Fix #27 <https://github.com/robotics-in-concert/rocon/issues/27>
* Contributors: Jihoon Lee
```
