### PR TITLE
gopher_concert: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -194,6 +194,24 @@ repositories:
       version: indigo-devel
     status: end-of-life
     status_description: Moving python dependencies to corresponding package repository
+  gopher_concert:
+    doc:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_concert.git
+      version: indigo
+    release:
+      packages:
+      - gocart_concert
+      - gopher_concert
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/gopher_concert-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: git@bitbucket.org:yujinrobot/gopher_concert.git
+      version: indigo
+    status: developed
   gopher_crazy_hospital:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gopher_concert` to `0.1.1-0`:
- upstream repository: git@bitbucket.org:yujinrobot/gopher_concert.git
- release repository: git@bitbucket.org:yujinrobot/gopher_concert-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## gocart_concert

```
* working version for spain field test
```
## gopher_concert

```
* working version for spain field test
```
