### PR TITLE
flask-task-planner: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -194,6 +194,23 @@ repositories:
       version: indigo-devel
     status: end-of-life
     status_description: Moving python dependencies to corresponding package repository
+  flask-task-planner:
+    doc:
+      type: git
+      url: git@bitbucket.org:yujinrobot/flask-task-planner.git
+      version: indigo
+    release:
+      packages:
+      - flask_task_planner
+      tags:
+        release: release/indigo/{package}/{version}
+      url: git@bitbucket.org:yujinrobot/flask-task-planner-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: git@bitbucket.org:yujinrobot/flask-task-planner.git
+      version: indigo
+    status: developed
   gopher_concert:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flask-task-planner` to `0.1.1-0`:
- upstream repository: git@bitbucket.org:yujinrobot/flask-task-planner.git
- release repository: git@bitbucket.org:yujinrobot/flask-task-planner-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## flask_task_planner

```
* working version for spain field test
```
