### PR TITLE
celeros: 0.0.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15,7 +15,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:yujinrobot/celeros-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/asmodehn/celeros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `celeros` to `0.0.2-1`:
- upstream repository: https://github.com/asmodehn/celeros.git
- release repository: git@bitbucket.org:yujinrobot/celeros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.2-0`
