### PR TITLE
elevator_interactions: 0.1.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -170,7 +170,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:yujinrobot/elevator_interactions-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: git@bitbucket.org:yujinrobot/elevator_interactions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `elevator_interactions` to `0.1.0-2`:
- upstream repository: git@bitbucket.org:yujinrobot/elevator_interactions.git
- release repository: git@bitbucket.org:yujinrobot/elevator_interactions-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.0-1`
