### PR TITLE
rocon_app_platform: 0.8.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -335,7 +335,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: git@bitbucket.org:yujinrobot/rocon_app_platform-release.git
-      version: 0.8.0-0
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/robotics-in-concert/rocon_app_platform.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rocon_app_platform` to `0.8.0-1`:
- upstream repository: https://github.com/robotics-in-concert/rocon_app_platform.git
- release repository: git@bitbucket.org:yujinrobot/rocon_app_platform-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.8.0-0`
## rocon_app_manager

```
* provide args to the user so they can prepare for unique namespacing if necessary
* move rapp launching into the root namespace and let the user decide where handles should go
* advertise the rapp manager handles on the gateway by default for concert clients
* simplified launchers into standalone and concert client
* split standalone and concert classes rather than trying to mash them as one
```
## rocon_app_platform

```
* rapps now launching in the root namespace, let the user decide
```
