### PR TITLE
marshmallow: 2.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -306,6 +306,23 @@ repositories:
       url: git@bitbucket.org:yujinrobot/gopher_rocon.git
       version: indigo
     status: developed
+  marshmallow:
+    doc:
+      type: git
+      url: https://github.com/marshmallow-code/marshmallow.git
+      version: :{version}
+    release:
+      packages:
+      - python-marshmallow
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/marshmallow-rosrelease.git
+      version: 2.2.1-0
+    source:
+      type: git
+      url: https://github.com/marshmallow-code/marshmallow.git
+      version: :{version}
+    status: maintained
   rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marshmallow` to `2.2.1-0`:
- upstream repository: https://github.com/marshmallow-code/marshmallow.git
- release repository: https://github.com/asmodehn/marshmallow-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## python-marshmallow

```
Bug fixes:
* Skip field validators for fields that aren't included in ``only`` (:issue:`320`). Thanks :user:`carlos-alberto` for reporting and :user:`eprikazc` for the PR.
```
