### PR TITLE
marshmallow: 2.2.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -317,7 +317,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/marshmallow-rosrelease.git
-      version: 2.2.1-0
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/marshmallow-code/marshmallow.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marshmallow` to `2.2.1-1`:
- upstream repository: https://github.com/marshmallow-code/marshmallow.git
- release repository: https://github.com/asmodehn/marshmallow-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.2.1-0`
## python-marshmallow

```
Bug fixes:
* Skip field validators for fields that aren't included in ``only`` (:issue:`320`). Thanks :user:`carlos-alberto` for reporting and :user:`eprikazc` for the PR.
```
