### PR TITLE
marshmallow: 2.2.1-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -313,7 +313,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/marshmallow-rosrelease.git
-      version: 2.2.1-3
+      version: 2.2.1-4
     status: maintained
   rocon:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `marshmallow` to `2.2.1-4`:
- upstream repository: https://github.com/marshmallow-code/marshmallow.git
- release repository: https://github.com/asmodehn/marshmallow-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.2.1-3`
## python-marshmallow

```
Bug fixes:
* Skip field validators for fields that aren't included in ``only`` (:issue:`320`). Thanks :user:`carlos-alberto` for reporting and :user:`eprikazc` for the PR.
```
