### PR TITLE
webargs: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -552,5 +552,14 @@ repositories:
       url: https://github.com/yujinrobot/somanet_msgs.git
       version: indigo
     status: developed
+  webargs:
+    release:
+      packages:
+      - python_webargs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/webargs-rosrelease.git
+      version: 1.1.1-0
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `webargs` to `1.1.1-0`:
- upstream repository: https://github.com/sloria/webargs.git
- release repository: https://github.com/asmodehn/webargs-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## python_webargs

```
Bug fixes:
* aiohttpparser: Fix bug that raised a ``JSONDecodeError`` raised when parsing non-JSON requests using default ``locations`` (:issue:`80`). Thanks :user:`leonidumanskiy` for reporting.
* Fix parsing JSON requests that have a vendor media type, e.g. ``application/vnd.api+json``.
```
