### PR TITLE
python-tblib: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -315,6 +315,15 @@ repositories:
       url: https://github.com/asmodehn/marshmallow-rosrelease.git
       version: 2.2.1-4
     status: maintained
+  python-tblib:
+    release:
+      packages:
+      - python_tblib
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/python-tblib-rosrelease.git
+      version: 1.1.0-0
+    status: maintained
   rocon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python-tblib` to `1.1.0-0`:
- upstream repository: https://github.com/ionelmc/python-tblib.git
- release repository: https://github.com/asmodehn/python-tblib-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
