### PR TITLE
pyros_test: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -315,6 +315,27 @@ repositories:
       url: https://github.com/asmodehn/marshmallow-rosrelease.git
       version: 2.2.1-4
     status: maintained
+  pyros:
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros.git
+      version: indigo-devel
+    status: developed
+  pyros_test:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: indigo
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/pyros-test-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: indigo
+    status: developed
   python-tblib:
     release:
       packages:
@@ -527,12 +548,6 @@ repositories:
     source:
       type: git
       url: https://github.com/asmodehn/rostful.git
-      version: indigo-devel
-    status: developed
-  pyros:
-    source:
-      type: git
-      url: https://github.com/asmodehn/pyros.git
       version: indigo-devel
     status: developed
   somanet_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.1-0`:
- upstream repository: https://github.com/asmodehn/pyros-test.git
- release repository: https://github.com/asmodehn/pyros-test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
