### PR TITLE
pyros_setup: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -330,7 +330,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/asmodehn/pyros-setup-release.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/asmodehn/pyros-setup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_setup` to `0.0.1-1`:
- upstream repository: https://github.com/asmodehn/pyros-setup.git
- release repository: https://github.com/asmodehn/pyros-setup-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.1-0`
