### PR TITLE
caktin_pure_python: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6,6 +6,23 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
+  caktin_pure_python:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/catkin_pure_python.git
+      version: indigo
+    release:
+      packages:
+      - catkin_pure_python
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/asmodehn/catkin_pure_python-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/asmodehn/catkin_pure_python.git
+      version: indigo
+    status: developed
   celeros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `caktin_pure_python` to `0.0.1-1`:
- upstream repository: https://github.com/asmodehn/catkin_pure_python.git
- release repository: https://github.com/asmodehn/catkin_pure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## catkin_pure_python

```
* Provides catkin_npm_update_target() and catkin_npm_update_once()
* Contributors: AlexV
```
