### PR TITLE
python-sphinx-rtd-theme -> gopher_sphinx-rtd-theme

### DIFF
--- a/rosdep/yujinrobot-system.yaml
+++ b/rosdep/yujinrobot-system.yaml
@@ -22,7 +22,7 @@ plantuml:
   ubuntu: plantuml-yujin
 python-anyconfig:
   ubuntu: [python-anyconfig]
-python-sphinx-rtd-theme:
+gopher-sphinx-rtd-theme:
   ubuntu: [python-sphinx-rtd-theme]
 python-yujin-tools:
   ubuntu: [python-yujin-tools]


### PR DESCRIPTION
The rosdep would point to [ros/rosdistro](https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L2563) which would fail to lookup definition for trusty giving out: `No definition of [python-sphinx-rtd-theme] for OS version [trusty]`.

This would temporarily resolve this name lookup.

some discussion about this [here](https://github.com/yujinrobot/rosdistro/commit/adddbd0039eb895ed1cc1f4d6887b0d545dea390)